### PR TITLE
fix: remove Crowdin footer link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,7 +221,6 @@ const config = {
             title: "More",
             items: [
               { label: "Blog", to: "/blog" },
-              { label: "Translate on Crowdin", href: "https://crowdin.com/project/wppconnect-site" },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- Remove the `Translate on Crowdin` link from the footer `More` column.

## Validation
- Confirmed `Translate on Crowdin` no longer appears in source.
- `npm run build` passed after the removal.