### PR TITLE
fix: update ecosystem projects and pt-BR translations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,12 +52,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci || npm install
 
-      - name: Crowdin Sync
-        run: npm run crowdin:sync
-        continue-on-error: true
-        env:
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-
       - name: Build Page
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@
 # Production
 /build
 
-# i18n is managed by Crowdin — only commit the source code.json files
+# Keep committed translations for custom UI and theme chrome.
 /i18n/**/*
 !/i18n/pt-BR/
 !/i18n/pt-BR/code.json
+!/i18n/pt-BR/docusaurus-theme-classic/
+!/i18n/pt-BR/docusaurus-theme-classic/*.json
 
 # Generated files
 .docusaurus
@@ -24,5 +26,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+docusaurus-serve-*.log
 
 pnpm-lock.yaml

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,7 +221,6 @@ const config = {
             title: "More",
             items: [
               { label: "Blog", to: "/blog" },
-              { label: "Translate on Crowdin", href: "https://crowdin.com/project/wppconnect-site" },
             ],
           },
         ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,11 +113,6 @@ const config = {
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },
-      announcementBar: {
-        id: "support_us_v2", // Increment on change
-        content:
-          'Use WPPConnect for free. Help us keep it moving: <a target="_blank" rel="noopener noreferrer" href="https://github.com/wppconnect-team/wppconnect">contribute code</a> or <a target="_blank" rel="noopener noreferrer" href="https://opencollective.com/wppconnect">sponsor the project</a>.',
-      },
       navbar: {
         hideOnScroll: false,
         title: "WPPConnect",
@@ -153,16 +148,6 @@ const config = {
           {
             type: "localeDropdown",
             position: "right",
-            dropdownItemsAfter: [
-              {
-                type: "html",
-                value: '<hr style="margin: 0.3rem 0;">',
-              },
-              {
-                href: "https://crowdin.com/project/wppconnect-site",
-                label: "Help Us Translate",
-              },
-            ],
           },
           {
             href: "https://discord.gg/JU5JGGKGNG",
@@ -195,7 +180,7 @@ const config = {
               { label: "Library", href: "https://github.com/wppconnect-team/wppconnect" },
               { label: "Server", href: "https://github.com/wppconnect-team/wppconnect-server" },
               { label: "WA-JS", href: "https://github.com/wppconnect-team/wa-js" },
-              { label: "Docker", href: "https://github.com/wppconnect-team/wpp-docker" },
+              { label: "WPP4Delphi", href: "https://github.com/wppconnect-team/WPP4Delphi" },
             ],
           },
           {

--- a/i18n/pt-BR/code.json
+++ b/i18n/pt-BR/code.json
@@ -72,13 +72,13 @@
     "message": "Contribuir com código"
   },
   "home.eco.lib.desc": {
-    "message": "A biblioteca core em Node.js. Envie mensagens, construa bots e automatize qualquer fluxo do WhatsApp Web por uma API limpa."
+    "message": "O projeto mais estrelado do ecossistema: uma biblioteca Node.js para enviar mensagens, construir bots e automatizar fluxos do WhatsApp Web."
   },
   "server.robust.desc": {
-    "message": "Um servidor simples e robusto em NodeJS, com todas as funções que o WPPConnect oferece."
+    "message": "Uma API REST pronta para uso, baseada no WPPConnect, para sessões, mensagens, contatos, grupos e webhooks."
   },
-  "extension.desc": {
-    "message": "WA-JS é uma biblioteca open-source feita para integrar e automatizar o WhatsApp Web com facilidade, permitindo criar extensões e usar diretamente no console do navegador."
+  "home.eco.wajs.desc": {
+    "message": "Automação do WhatsApp Web no navegador para alimentar extensões, integrações e fluxos diretamente pelo console."
   },
   "docker.description": {
     "message": "Sim, também disponibilizamos Docker. Veja clicando no botão abaixo."
@@ -96,13 +96,16 @@
     "message": "Ver todos os repositórios"
   },
   "home.eco.tools.eyebrow": {
-    "message": "Clientes e ferramentas"
+    "message": "Repositórios populares"
   },
   "home.eco.delphi.desc": {
-    "message": "Leve a automação do WhatsApp Web para o ecossistema Delphi."
+    "message": "Leve a automação do WhatsApp Web para o ecossistema Delphi com um projeto da comunidade criado em torno do WPPConnect."
   },
   "home.eco.waversion.desc": {
     "message": "Registro sempre atualizado das versões do WhatsApp Web, atualizado automaticamente."
+  },
+  "home.eco.waproto.desc": {
+    "message": "Arquivos Protobuf do WhatsApp Web com verificações e atualizações automatizadas."
   },
   "home.eco.php.desc": {
     "message": "Um cliente PHP simples para acessar os endpoints do WPPConnect Server com facilidade."
@@ -119,6 +122,12 @@
   "home.eco.mobile.desc": {
     "message": "Automação rodando o WhatsApp Web direto em navegadores móveis Android e iOS."
   },
+  "home.eco.api.desc": {
+    "message": "Um pequeno servidor de API que fornece previews de URL para a biblioteca WA-JS."
+  },
+  "home.eco.extension.desc": {
+    "message": "Projeto de extensão de navegador para fluxos do WhatsApp Web impulsionados pelo ecossistema WPPConnect."
+  },
   "home.eco.lib.badge": {
     "message": "Biblioteca"
   },
@@ -130,6 +139,9 @@
   },
   "home.eco.docker.badge": {
     "message": "Container"
+  },
+  "home.eco.delphi.badge": {
+    "message": "Delphi"
   },
   "view": {
     "message": "Ver"

--- a/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -1,0 +1,74 @@
+{
+  "link.title.Docs": {
+    "message": "Documentos",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "Comunidade",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "Mais",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Tutorial": {
+    "message": "Tutorial",
+    "description": "The label of footer link with label=Tutorial linking to /docs/tutorial/intro"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/JU5JGGKGNG"
+  },
+  "link.item.label.YouTube": {
+    "message": "YouTube",
+    "description": "The label of footer link with label=YouTube linking to https://www.youtube.com/c/wppconnect"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/wppconnect-team"
+  },
+  "link.item.label.Contribute code": {
+    "message": "Contribuir com código",
+    "description": "The label of footer link with label=Contribute code linking to https://github.com/wppconnect-team/wppconnect"
+  },
+  "link.item.label.Sponsor on Open Collective": {
+    "message": "Patrocinar no Open Collective",
+    "description": "The label of footer link with label=Sponsor on Open Collective linking to https://opencollective.com/wppconnect"
+  },
+  "copyright": {
+    "message": "Copyright © 2026 WPPConnect Team. Automação open-source para WhatsApp mantida por mantenedores, patrocinadores e contribuidores. Use de graça, melhore no GitHub ou ajude a financiar o próximo release no Open Collective.",
+    "description": "The footer copyright"
+  },
+  "link.title.Product": {
+    "message": "Produto",
+    "description": "The title of the footer links column with title=Product in the footer"
+  },
+  "link.item.label.Library": {
+    "message": "Biblioteca",
+    "description": "The label of footer link with label=Library linking to https://github.com/wppconnect-team/wppconnect"
+  },
+  "link.item.label.Server": {
+    "message": "Servidor",
+    "description": "The label of footer link with label=Server linking to https://github.com/wppconnect-team/wppconnect-server"
+  },
+  "link.item.label.WPP4Delphi": {
+    "message": "WPP4Delphi",
+    "description": "The label of footer link with label=WPP4Delphi linking to https://github.com/wppconnect-team/WPP4Delphi"
+  },
+  "link.item.label.Projects": {
+    "message": "Projetos",
+    "description": "The label of footer link with label=Projects linking to /docs/projects"
+  },
+  "link.item.label.Swagger": {
+    "message": "Swagger",
+    "description": "The label of footer link with label=Swagger linking to /swagger/wppconnect-server"
+  },
+  "link.item.label.WhatsApp Versions": {
+    "message": "Versões do WhatsApp",
+    "description": "The label of footer link with label=WhatsApp Versions linking to /whatsapp-versions"
+  }
+}

--- a/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,58 @@
+{
+  "title": {
+    "message": "WPPConnect",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "WPPconnect Logo",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "Documentos",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Tutorial": {
+    "message": "Tutorial",
+    "description": "Navbar item with label Tutorial"
+  },
+  "item.label.Projects": {
+    "message": "Projetos",
+    "description": "Navbar item with label Projects"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Navbar item with label API"
+  },
+  "item.label.Swagger": {
+    "message": "Swagger",
+    "description": "Navbar item with label Swagger"
+  },
+  "item.label.WhatsApp Versions": {
+    "message": "Versões do WhatsApp",
+    "description": "Navbar item with label WhatsApp Versions"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Navbar item with label Blog"
+  },
+  "item.label.WA-JS": {
+    "message": "WA-JS",
+    "description": "Navbar item with label WA-JS"
+  },
+  "item.label.WPPConnect": {
+    "message": "WPPConnect",
+    "description": "Navbar item with label WPPConnect"
+  },
+  "item.label.Overview": {
+    "message": "Visão geral",
+    "description": "Navbar item with label Overview"
+  },
+  "item.label.WPPConnect (library)": {
+    "message": "WPPConnect (biblioteca)",
+    "description": "Navbar item with label WPPConnect (library)"
+  },
+  "item.label.Server (Swagger)": {
+    "message": "Server (Swagger)",
+    "description": "Navbar item with label Server (Swagger)"
+  }
+}

--- a/src/components/Home/v2/Ecosystem.tsx
+++ b/src/components/Home/v2/Ecosystem.tsx
@@ -4,7 +4,6 @@ import {
   ArrowRight,
   Code2,
   Server,
-  Boxes,
   MonitorSmartphone,
   Smartphone,
   Star,
@@ -38,12 +37,12 @@ const PRODUCTS: Product[] = [
     title: "WPPConnect",
     desc: (
       <Translate id="home.eco.lib.desc">
-        The core Node.js library. Send messages, build bots and automate any
-        WhatsApp Web flow through a clean API.
+        The most starred project in the ecosystem: a Node.js library to send
+        messages, build bots, and automate WhatsApp Web flows.
       </Translate>
     ),
     href: "https://github.com/wppconnect-team/wppconnect",
-    stars: "3.3k",
+    stars: "3.4k",
     icon: <Code2 size={22} />,
     accent: "rgba(37, 211, 102, 0.35)",
     variant: "green",
@@ -54,8 +53,8 @@ const PRODUCTS: Product[] = [
     title: "WPPConnect Server",
     desc: (
       <Translate id="server.robust.desc">
-        A simple and robust server made in NodeJS, with all the functions that
-        WPPConnect offers.
+        A ready-to-use REST API built on WPPConnect for sessions, messages,
+        contacts, groups, and webhooks.
       </Translate>
     ),
     href: "https://github.com/wppconnect-team/wppconnect-server",
@@ -69,31 +68,30 @@ const PRODUCTS: Product[] = [
     badge: <Translate id="home.eco.wajs.badge">Frontend</Translate>,
     title: "WA-JS",
     desc: (
-      <Translate id="extension.desc">
-        WA-JS is an open-source library designed for easy integration and
-        automation of WhatsApp Web, allowing developers to create extensions and
-        use it directly in the browser console.
+      <Translate id="home.eco.wajs.desc">
+        Browser-side WhatsApp Web automation used to power extensions,
+        integrations, and direct console workflows.
       </Translate>
     ),
     href: "https://github.com/wppconnect-team/wa-js",
-    stars: "740",
+    stars: "766",
     icon: <MonitorSmartphone size={22} />,
     accent: "rgba(139, 92, 246, 0.35)",
     variant: "violet",
     featured: true,
   },
   {
-    badge: <Translate id="home.eco.docker.badge">Container</Translate>,
-    title: "WPP Docker",
+    badge: <Translate id="home.eco.delphi.badge">Delphi</Translate>,
+    title: "WPP4Delphi",
     desc: (
-      <Translate id="docker.description">
-        Seriously, we're even making Docker available. Check it out by clicking
-        the button below
+      <Translate id="home.eco.delphi.desc">
+        Bring WhatsApp Web automation to the Delphi ecosystem with a community
+        project built around WPPConnect.
       </Translate>
     ),
-    href: "https://github.com/wppconnect-team/wpp-docker",
-    stars: "154",
-    icon: <Boxes size={22} />,
+    href: "https://github.com/wppconnect-team/WPP4Delphi",
+    stars: "243",
+    icon: <Layers size={22} />,
     accent: "rgba(236, 72, 153, 0.35)",
     variant: "default",
     featured: true,
@@ -110,17 +108,6 @@ type Tool = {
 
 const TOOLS: Tool[] = [
   {
-    title: "WPP4Delphi",
-    desc: (
-      <Translate id="home.eco.delphi.desc">
-        Bring WhatsApp Web automation to the Delphi ecosystem.
-      </Translate>
-    ),
-    href: "https://github.com/wppconnect-team/WPP4Delphi",
-    stars: "243",
-    icon: <Layers size={20} />,
-  },
-  {
     title: "wa-version",
     desc: (
       <Translate id="home.eco.waversion.desc">
@@ -132,32 +119,21 @@ const TOOLS: Tool[] = [
     icon: <Package size={20} />,
   },
   {
-    title: "PHP Client",
+    title: "wa-proto",
     desc: (
-      <Translate id="home.eco.php.desc">
-        A simple PHP client to access the WPPConnect Server endpoints with ease.
+      <Translate id="home.eco.waproto.desc">
+        Protobuf files from WhatsApp Web with automated checks and updates.
       </Translate>
     ),
-    href: "https://github.com/wppconnect-team/wppconnect-php-client",
+    href: "https://github.com/wppconnect-team/wa-proto",
     stars: "47",
-    icon: <Code2 size={20} />,
-  },
-  {
-    title: "Laravel Client",
-    desc: (
-      <Translate id="home.eco.laravel.desc">
-        A clean Guzzle-based wrapper providing easy access to WPPConnect Server.
-      </Translate>
-    ),
-    href: "https://github.com/wppconnect-team/wppconnect-laravel-client",
-    stars: "40",
-    icon: <Code2 size={20} />,
+    icon: <Package size={20} />,
   },
   {
     title: "server-cli",
     desc: (
       <Translate id="home.eco.cli.desc">
-        Command-line interface to manage the WPPConnect Server quickly.
+        Command-line interface to manage WPPConnect Server quickly.
       </Translate>
     ),
     href: "https://github.com/wppconnect-team/server-cli",
@@ -165,26 +141,38 @@ const TOOLS: Tool[] = [
     icon: <Terminal size={20} />,
   },
   {
-    title: "Frontend Vue",
-    desc: (
-      <Translate id="home.eco.vue.desc">
-        Ready-to-use Vue frontend that talks to WPPConnect Server.
-      </Translate>
-    ),
-    href: "https://github.com/wppconnect-team/wppconnect-frontend-vue",
-    stars: "28",
-    icon: <MonitorSmartphone size={20} />,
-  },
-  {
-    title: "Mobile",
+    title: "mobile",
     desc: (
       <Translate id="home.eco.mobile.desc">
         Automation that runs WhatsApp Web inside Android and iOS mobile browsers.
       </Translate>
     ),
     href: "https://github.com/wppconnect-team/mobile",
-    stars: "25",
+    stars: "26",
     icon: <Smartphone size={20} />,
+  },
+  {
+    title: "wa-js-api-server",
+    desc: (
+      <Translate id="home.eco.api.desc">
+        A small API server that provides URL previews for the WA-JS library.
+      </Translate>
+    ),
+    href: "https://github.com/wppconnect-team/wa-js-api-server",
+    stars: "22",
+    icon: <Server size={20} />,
+  },
+  {
+    title: "wppconnect-extension",
+    desc: (
+      <Translate id="home.eco.extension.desc">
+        Browser extension project for WhatsApp Web workflows powered by the
+        WPPConnect ecosystem.
+      </Translate>
+    ),
+    href: "https://github.com/wppconnect-team/wppconnect-extension",
+    stars: "15",
+    icon: <MonitorSmartphone size={20} />,
   },
 ];
 
@@ -368,7 +356,9 @@ const EcosystemV2: React.FC = () => (
               textTransform: "uppercase",
             }}
           >
-            <Translate id="home.eco.tools.eyebrow">Clients & tools</Translate>
+            <Translate id="home.eco.tools.eyebrow">
+              Popular repositories
+            </Translate>
           </span>
           <span
             aria-hidden


### PR DESCRIPTION
## Summary
- update the home ecosystem section using the most-starred public WPPConnect Team repositories
- replace stale/404 Docker references with WPP4Delphi
- commit pt-BR theme translations and stop publish from downloading stale Crowdin translations
- remove untranslated announcement/Crowdin dropdown chrome from the localized site

## Validation
- npx docusaurus build --locale pt-BR --no-minify
- HTTP check on local build at http://127.0.0.1:3010/ confirmed pt-BR ecosystem text, WPP4Delphi, no wpp-docker, no English announcement, and no Crowdin dropdown

Note: npm run typecheck still fails on the existing tsconfig setting: moduleResolution Node16 requires module Node16.