### PR TITLE
ci: set explicit workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-blog.yml
+++ b/.github/workflows/update-blog.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 23 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update_blog:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-lock.yml
+++ b/.github/workflows/update-lock.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: write
+
 jobs:
   update-lock:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-whatsapp-versions.yml
+++ b/.github/workflows/update-whatsapp-versions.yml
@@ -3,6 +3,9 @@ name: Update WhatsApp Versions
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update_whatsapp_versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- declare least-privilege `GITHUB_TOKEN` permissions for every flagged workflow
- preserve write access only where the workflow publishes or commits generated files
- keep read-only jobs restricted to repository contents

## Validation
- all modified workflows parse as valid YAML
- `actionlint` v1.7.7 passes
- `git diff --check` passes

## Security
This addresses the open `actions/missing-workflow-permissions` code-scanning findings. AI-assisted changes were reviewed and validated before submission.