### PR TITLE
feat: launch the B2B support pilot page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,11 @@ const config = {
             label: "WhatsApp Versions",
             position: "left",
           },
+          {
+            to: "/business-support",
+            label: "Business Support",
+            position: "left",
+          },
           { to: "/blog", label: "Blog", position: "left" },
           {
             type: "localeDropdown",
@@ -190,6 +195,7 @@ const config = {
               { label: "Projects", to: "/docs/projects" },
               { label: "Swagger", to: "/swagger/wppconnect-server" },
               { label: "WhatsApp Versions", to: "/whatsapp-versions" },
+              { label: "Business Support", to: "/business-support" },
             ],
           },
           {

--- a/i18n/pt-BR/code.json
+++ b/i18n/pt-BR/code.json
@@ -247,5 +247,101 @@
   },
   "home.why.intro": {
     "message": "WPPConnect não é um produto. É uma fundação aberta onde desenvolvedores, agências e times constroem a próxima geração de software conversacional sobre o WhatsApp."
+  },
+  "sponsor.businessSupport": {
+    "message": "Resposta prioritária a incidentes e metas documentadas de mitigação para empresas que usam WA-JS ou WPPConnect em produção."
+  },
+  "sponsor.businessSupport.cta": {
+    "message": "Conhecer o piloto B2B"
+  },
+  "businessSupport.enterpriseBadge": {
+    "message": "Resposta mais rápida"
+  },
+  "businessSupport.perMonth": {
+    "message": "/mês"
+  },
+  "businessSupport.initialResponse": {
+    "message": "Resposta inicial"
+  },
+  "businessSupport.mitigationTarget": {
+    "message": "Meta de mitigação"
+  },
+  "businessSupport.apply": {
+    "message": "Candidatar-se ao piloto"
+  },
+  "businessSupport.pilot": {
+    "message": "Piloto B2B limitado"
+  },
+  "businessSupport.title": {
+    "message": "Incidentes de produção merecem um caminho direto até os mantenedores."
+  },
+  "businessSupport.subtitle": {
+    "message": "Triagem prioritária e metas documentadas de mitigação para regressões reproduzíveis do WA-JS e WPPConnect que interrompem a produção."
+  },
+  "businessSupport.hours": {
+    "message": "Cobertura: segunda a sexta, 09h–18h BRT, exceto feriados nacionais brasileiros."
+  },
+  "businessSupport.enrollmentTitle": {
+    "message": "Status da adesão"
+  },
+  "businessSupport.enrollmentBody": {
+    "message": "O perfil de patrocínio da organização está sendo preparado. As candidaturas ao piloto são atendidas pelo Discord oficial até a cobrança da organização estar disponível."
+  },
+  "businessSupport.proResponse": {
+    "message": "Até 8 horas úteis"
+  },
+  "businessSupport.proMitigation": {
+    "message": "48 horas após a confirmação"
+  },
+  "businessSupport.enterpriseResponse": {
+    "message": "Até 2 horas úteis"
+  },
+  "businessSupport.enterpriseMitigation": {
+    "message": "24 horas após a confirmação"
+  },
+  "businessSupport.logo": {
+    "message": "Logo da empresa no README do projeto"
+  },
+  "businessSupport.privateIssue": {
+    "message": "Entrada privada de incidentes e triagem prioritária"
+  },
+  "businessSupport.webhookIncluded": {
+    "message": "Webhook de compatibilidade incluído quando disponível"
+  },
+  "businessSupport.channel": {
+    "message": "Canal privado dedicado no Discord"
+  },
+  "businessSupport.howItWorks": {
+    "message": "Como funciona a meta de serviço"
+  },
+  "businessSupport.covered": {
+    "message": "Coberto"
+  },
+  "businessSupport.coveredBody": {
+    "message": "Regressões reproduzíveis em versões suportadas do WA-JS ou WPPConnect que interrompam um fluxo de produção existente."
+  },
+  "businessSupport.mitigation": {
+    "message": "Mitigação"
+  },
+  "businessSupport.mitigationBody": {
+    "message": "Patch, versão compatível, pin de versão, feature flag ou contorno documentado que restaure o fluxo afetado."
+  },
+  "businessSupport.excluded": {
+    "message": "Não coberto"
+  },
+  "businessSupport.excludedBody": {
+    "message": "Banimentos, aplicação de políticas da Meta, infraestrutura do cliente, versões não suportadas, código customizado ou integração incorreta."
+  },
+  "businessSupport.disclaimer": {
+    "message": "As metas começam após reprodução e confirmação do problema. São metas de resposta e mitigação, não garantia de que alterações de plataformas de terceiros sempre possam ser revertidas."
+  },
+  "businessSupport.threeCompanies": {
+    "message": "Três empresas, depois medimos."
+  },
+  "businessSupport.threeCompaniesBody": {
+    "message": "A primeira turma é limitada a duas empresas Pro e uma Enterprise, para o time validar capacidade e publicar resultados reais do nível de serviço."
+  },
+  "businessSupport.talk": {
+    "message": "Falar com o time"
   }
 }

--- a/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -70,5 +70,9 @@
   "link.item.label.WhatsApp Versions": {
     "message": "Versões do WhatsApp",
     "description": "The label of footer link with label=WhatsApp Versions linking to /whatsapp-versions"
+  },
+  "link.item.label.Business Support": {
+    "message": "Suporte empresarial",
+    "description": "The label of footer link with label=Business Support linking to /business-support"
   }
 }

--- a/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -31,6 +31,10 @@
     "message": "Versões do WhatsApp",
     "description": "Navbar item with label WhatsApp Versions"
   },
+  "item.label.Business Support": {
+    "message": "Suporte empresarial",
+    "description": "Navbar item with label Business Support"
+  },
   "item.label.Blog": {
     "message": "Blog",
     "description": "Navbar item with label Blog"

--- a/src/components/Home/v2/Sponsor.tsx
+++ b/src/components/Home/v2/Sponsor.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Translate from "@docusaurus/Translate";
-import { ArrowRight, Code2, Heart, Youtube } from "lucide-react";
+import { ArrowRight, BriefcaseBusiness, Code2, Heart, Youtube } from "lucide-react";
 import Container from "@site/src/components/ui/Container";
 import Section from "@site/src/components/ui/Section";
 import Card from "@site/src/components/ui/Card";
@@ -19,6 +19,18 @@ type Item = {
 };
 
 const ITEMS: Item[] = [
+  {
+    icon: <BriefcaseBusiness size={22} />,
+    title: "Business Support",
+    body: (
+      <Translate id="sponsor.businessSupport">
+        Priority incident response and documented mitigation targets for companies running WA-JS or WPPConnect in production.
+      </Translate>
+    ),
+    link: "/business-support",
+    linkLabel: <Translate id="sponsor.businessSupport.cta">See the B2B pilot</Translate>,
+    accent: "rgba(14, 165, 233, 0.35)",
+  },
   {
     icon: <Heart size={22} />,
     title: "Open Collective",

--- a/src/pages/business-support/index.module.scss
+++ b/src/pages/business-support/index.module.scss
@@ -1,0 +1,259 @@
+.page {
+  --support-green: #25d366;
+  background:
+    radial-gradient(circle at 75% 7%, rgba(37, 211, 102, 0.14), transparent 28rem),
+    var(--ifm-background-color);
+  min-height: 100vh;
+}
+
+.hero {
+  padding: clamp(5rem, 10vw, 8rem) 0 4rem;
+  border-bottom: 1px solid var(--wpp-border);
+}
+
+.hero h1 {
+  max-width: 900px;
+  margin: 1.2rem 0;
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.eyebrow,
+.availability {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.eyebrow {
+  padding: 0.45rem 0.8rem;
+  color: var(--support-green);
+  border: 1px solid rgba(37, 211, 102, 0.35);
+  border-radius: 999px;
+  background: rgba(37, 211, 102, 0.08);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.lead {
+  max-width: 760px;
+  color: var(--wpp-muted);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  line-height: 1.65;
+}
+
+.availability {
+  margin-top: 1rem;
+  color: var(--ifm-font-color-base);
+  font-weight: 600;
+}
+
+.content {
+  padding-top: 3rem;
+  padding-bottom: 5rem;
+}
+
+.notice {
+  margin-bottom: 2rem;
+  padding: 1.15rem 1.3rem;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 14px;
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.notice p {
+  margin: 0.35rem 0 0;
+  color: var(--wpp-muted);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.tier {
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 2.3rem);
+  border: 1px solid var(--wpp-border);
+  border-radius: 22px;
+  background: var(--wpp-card-bg);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.08);
+}
+
+.featured {
+  border-color: rgba(37, 211, 102, 0.6);
+  box-shadow: 0 18px 60px rgba(37, 211, 102, 0.12);
+}
+
+.pill {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  color: #07130b;
+  background: var(--support-green);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.price {
+  margin: 0.75rem 0 1.5rem;
+  font-size: 2.6rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.price span {
+  margin-left: 0.3rem;
+  color: var(--wpp-muted);
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.targets {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin: 0 0 1.5rem;
+}
+
+.targets div {
+  padding: 0.9rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.targets dt {
+  color: var(--wpp-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.targets dd {
+  margin: 0.35rem 0 0;
+  font-weight: 700;
+}
+
+.tier ul {
+  display: grid;
+  gap: 0.8rem;
+  min-height: 8.5rem;
+  margin: 0 0 1.6rem;
+  padding: 0;
+  list-style: none;
+}
+
+.tier li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.tier li svg {
+  flex: 0 0 auto;
+  margin-top: 0.15rem;
+  color: var(--support-green);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.85rem 1.2rem;
+  border-radius: 11px;
+  color: #07130b;
+  background: var(--support-green);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.button:hover {
+  color: #07130b;
+  filter: brightness(1.06);
+  text-decoration: none;
+}
+
+.terms {
+  margin-top: 4rem;
+}
+
+.termGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.termGrid > div {
+  padding: 1.25rem;
+  border: 1px solid var(--wpp-border);
+  border-radius: 14px;
+}
+
+.termGrid h3 {
+  margin-top: 0;
+}
+
+.termGrid p,
+.disclaimer,
+.pilotCta p {
+  color: var(--wpp-muted);
+}
+
+.disclaimer {
+  margin-top: 1.2rem;
+  padding-left: 1rem;
+  border-left: 3px solid var(--support-green);
+}
+
+.pilotCta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-top: 4rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid var(--wpp-border);
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(37, 211, 102, 0.11), rgba(37, 211, 102, 0.02));
+}
+
+.pilotCta h2,
+.pilotCta p {
+  margin: 0;
+}
+
+.pilotCta p {
+  max-width: 720px;
+  margin-top: 0.6rem;
+}
+
+@media (max-width: 820px) {
+  .grid,
+  .termGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pilotCta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 520px) {
+  .targets {
+    grid-template-columns: 1fr;
+  }
+
+  .pill {
+    position: static;
+    display: inline-block;
+    margin-bottom: 1rem;
+  }
+}

--- a/src/pages/business-support/index.tsx
+++ b/src/pages/business-support/index.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Heading from "@theme/Heading";
+import Translate from "@docusaurus/Translate";
+import { ArrowRight, Check, Clock3, ShieldCheck } from "lucide-react";
+import styles from "./index.module.scss";
+
+const DISCORD_URL = "https://discord.gg/JU5JGGKGNG";
+
+type TierProps = {
+  name: string;
+  price: string;
+  response: React.ReactNode;
+  mitigation: React.ReactNode;
+  features: React.ReactNode[];
+  featured?: boolean;
+};
+
+function Tier({ name, price, response, mitigation, features, featured }: TierProps) {
+  return (
+    <article className={`${styles.tier} ${featured ? styles.featured : ""}`}>
+      {featured && (
+        <span className={styles.pill}>
+          <Translate id="businessSupport.enterpriseBadge">Fastest response</Translate>
+        </span>
+      )}
+      <Heading as="h2">{name}</Heading>
+      <p className={styles.price}>
+        {price}
+        <span>
+          <Translate id="businessSupport.perMonth">/month</Translate>
+        </span>
+      </p>
+      <dl className={styles.targets}>
+        <div>
+          <dt><Translate id="businessSupport.initialResponse">Initial response</Translate></dt>
+          <dd>{response}</dd>
+        </div>
+        <div>
+          <dt><Translate id="businessSupport.mitigationTarget">Mitigation target</Translate></dt>
+          <dd>{mitigation}</dd>
+        </div>
+      </dl>
+      <ul>
+        {features.map((feature, index) => (
+          <li key={index}><Check size={18} aria-hidden />{feature}</li>
+        ))}
+      </ul>
+      <a className={styles.button} href={DISCORD_URL} target="_blank" rel="noreferrer">
+        <Translate id="businessSupport.apply">Apply for the pilot</Translate>
+        <ArrowRight size={18} aria-hidden />
+      </a>
+    </article>
+  );
+}
+
+export default function BusinessSupport(): JSX.Element {
+  return (
+    <Layout
+      title="Business Support"
+      description="Priority incident response and mitigation targets for companies running WPPConnect in production."
+    >
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <div className="container">
+            <span className={styles.eyebrow}>
+              <ShieldCheck size={17} aria-hidden />
+              <Translate id="businessSupport.pilot">Limited B2B pilot</Translate>
+            </span>
+            <Heading as="h1">
+              <Translate id="businessSupport.title">Production incidents deserve a direct path to maintainers.</Translate>
+            </Heading>
+            <p className={styles.lead}>
+              <Translate id="businessSupport.subtitle">
+                Priority triage and documented mitigation targets for reproducible WA-JS and WPPConnect regressions that stop production.
+              </Translate>
+            </p>
+            <div className={styles.availability}>
+              <Clock3 size={18} aria-hidden />
+              <Translate id="businessSupport.hours">
+                Coverage: Monday–Friday, 09:00–18:00 BRT, excluding Brazilian national holidays.
+              </Translate>
+            </div>
+          </div>
+        </section>
+
+        <section className={`container ${styles.content}`}>
+          <div className={styles.notice}>
+            <strong><Translate id="businessSupport.enrollmentTitle">Enrollment status</Translate></strong>
+            <p>
+              <Translate id="businessSupport.enrollmentBody">
+                The organization sponsorship profile is being prepared. Pilot applications are handled through the official Discord until organization billing is available.
+              </Translate>
+            </p>
+          </div>
+
+          <div className={styles.grid}>
+            <Tier
+              name="Pro"
+              price="US$ 250"
+              response={<Translate id="businessSupport.proResponse">Up to 8 business hours</Translate>}
+              mitigation={<Translate id="businessSupport.proMitigation">48 hours after confirmation</Translate>}
+              features={[
+                <Translate id="businessSupport.logo">Company logo in the project README</Translate>,
+                <Translate id="businessSupport.privateIssue">Private incident intake and priority triage</Translate>,
+                <Translate id="businessSupport.webhookIncluded">Compatibility webhook included when available</Translate>,
+              ]}
+            />
+            <Tier
+              name="Enterprise"
+              price="US$ 500"
+              featured
+              response={<Translate id="businessSupport.enterpriseResponse">Up to 2 business hours</Translate>}
+              mitigation={<Translate id="businessSupport.enterpriseMitigation">24 hours after confirmation</Translate>}
+              features={[
+                <Translate id="businessSupport.logo">Company logo in the project README</Translate>,
+                <Translate id="businessSupport.channel">Dedicated private Discord channel</Translate>,
+                <Translate id="businessSupport.webhookIncluded">Compatibility webhook included when available</Translate>,
+              ]}
+            />
+          </div>
+
+          <section className={styles.terms}>
+            <Heading as="h2"><Translate id="businessSupport.howItWorks">How the service target works</Translate></Heading>
+            <div className={styles.termGrid}>
+              <div>
+                <Heading as="h3"><Translate id="businessSupport.covered">Covered</Translate></Heading>
+                <p><Translate id="businessSupport.coveredBody">Reproducible regressions in supported WA-JS or WPPConnect versions that interrupt an existing production flow.</Translate></p>
+              </div>
+              <div>
+                <Heading as="h3"><Translate id="businessSupport.mitigation">Mitigation</Translate></Heading>
+                <p><Translate id="businessSupport.mitigationBody">A patch, compatible version, version pin, feature flag, or documented workaround that restores the affected flow.</Translate></p>
+              </div>
+              <div>
+                <Heading as="h3"><Translate id="businessSupport.excluded">Not covered</Translate></Heading>
+                <p><Translate id="businessSupport.excludedBody">Account bans, Meta policy enforcement, customer infrastructure, unsupported versions, custom code, or incorrect integration.</Translate></p>
+              </div>
+            </div>
+            <p className={styles.disclaimer}>
+              <Translate id="businessSupport.disclaimer">
+                Targets begin after the issue is reproduced and confirmed. They are response and mitigation targets, not a guarantee that third-party platform changes can always be reversed.
+              </Translate>
+            </p>
+          </section>
+
+          <section className={styles.pilotCta}>
+            <div>
+              <Heading as="h2"><Translate id="businessSupport.threeCompanies">Three companies, then we measure.</Translate></Heading>
+              <p><Translate id="businessSupport.threeCompaniesBody">The first cohort is limited to two Pro companies and one Enterprise company so the team can validate capacity and publish real service-level results.</Translate></p>
+            </div>
+            <a className={styles.button} href={DISCORD_URL} target="_blank" rel="noreferrer">
+              <Translate id="businessSupport.talk">Talk to the team</Translate>
+              <ArrowRight size={18} aria-hidden />
+            </a>
+          </section>
+        </section>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

- add a bilingual Business Support page for the limited B2B pilot
- publish the Pro (US$250) and Enterprise (US$500) response and mitigation targets
- document coverage hours, eligible incidents, exclusions, and the three-company capacity limit
- add the offer to the main navigation, footer, and sponsorship section

## Safety and launch boundary

The page states that organization billing is still being prepared and routes applications to the official Discord. It does not activate billing or claim that GitHub Sponsors is ready. Legal/tax review and organization Sponsors enrollment remain launch prerequisites.

## Validation

- npm run typecheck
- npm run build (English and pt-BR)
- browser QA on /business-support and /pt-BR/business-support